### PR TITLE
@material-ui/styles

### DIFF
--- a/examples/nextjs-with-typescript/package.json
+++ b/examples/nextjs-with-typescript/package.json
@@ -8,6 +8,7 @@
     "@emotion/styled": "latest",
     "@emotion/server": "latest",
     "@material-ui/core": "next",
+    "@material-ui/styles": "latest",
     "clsx": "latest",
     "next": "latest",
     "react": "latest",


### PR DESCRIPTION
This app requires @material-ui/styles to run `_document.tsx` line 5 `import { ServerStyleSheets } from '@material-ui/styles'` 
The dependency was not listed here and wouldn't run until installed.
This resolves an issue which caused this example app to not load on initial start.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
